### PR TITLE
fix: scalar not transformed for object

### DIFF
--- a/src/TransformCustomScalars.ts
+++ b/src/TransformCustomScalars.ts
@@ -68,12 +68,12 @@ export class TransformCustomScalars {
     type: string,
   ): any {
     if (result) {
+      if (Array.isArray(result)) {
+        return result.map((item) => this.transform(item, type));
+      }
       const transformDefinition = this.transformDefinitions[type];
       if (transformDefinition) {
         return transformDefinition.parseValue(result);
-      }
-      if (Array.isArray(result)) {
-        return result.map((item) => this.transform(item, type));
       }
       if (typeof result === 'object') {
         const fieldDefinitions = this.typeDefinitions.get(type);

--- a/src/TransformCustomScalars.ts
+++ b/src/TransformCustomScalars.ts
@@ -68,6 +68,10 @@ export class TransformCustomScalars {
     type: string,
   ): any {
     if (result) {
+      const transformDefinition = this.transformDefinitions[type];
+      if (transformDefinition) {
+        return transformDefinition.parseValue(result);
+      }
       if (Array.isArray(result)) {
         return result.map((item) => this.transform(item, type));
       }
@@ -89,10 +93,6 @@ export class TransformCustomScalars {
           result[key] = this.transform(value, definition.name);
         }
         return result;
-      }
-      const transformDefinition = this.transformDefinitions[type];
-      if (transformDefinition) {
-        return transformDefinition.parseValue(result);
       }
     }
     return result;


### PR DESCRIPTION
Fix #50 

When custom scalar is defined for object (for example JSONObject),
it should also utilize the transform, so it should run before everything.
Current behavior will threat it as GraphQL property too which causes bug.